### PR TITLE
1.20.1 - Fixed Config Bug

### DIFF
--- a/src/main/java/com/leclowndu93150/particular/ClientStuff.java
+++ b/src/main/java/com/leclowndu93150/particular/ClientStuff.java
@@ -201,7 +201,7 @@ public class ClientStuff {
                 fireflyFrequency = dailyRandomList.get(random.nextInt(dailyRandomList.size())).floatValue();
             }
 
-            if (!ParticularConfig.waterSplash()) return;
+            if (!ParticularConfig.cascades()) return;
 
             Minecraft mc = Minecraft.getInstance();
             int renderDistance = mc.options.renderDistance().get();


### PR DESCRIPTION
Decoupled cascade and water splash option in config so both could be used separately. Before, there was an early return in the onClientTick method when waterSplash was disabled, when as far as I can tell it should have been checking to see if cascades was enabled. Now, splashes and cascades can be set separately. Fixes #26 .
