### PR TITLE
Trigger cascade particles when flowing water drops in elevation

### DIFF
--- a/versions/1.21.1/common/src/main/java/com/leclowndu93150/particular/CommonClass.java
+++ b/versions/1.21.1/common/src/main/java/com/leclowndu93150/particular/CommonClass.java
@@ -159,6 +159,19 @@ public class CommonClass {
 		if (state.is(Fluids.WATER) && above.is(Fluids.FLOWING_WATER) && below.is(Fluids.WATER)) {
 			return true;
 		}
+
+		// Spilled / flowing water that drops a block in elevation: emit a cascade where a
+		// falling water column lands (a pool, a flowing puddle, or bare ground). The FALLING
+		// property means the water above is dropping straight down, and we only fire at the
+		// base of the drop (where the fall doesn't continue) so a tall column isn't spammed.
+		if ((state.is(Fluids.WATER) || state.is(Fluids.FLOWING_WATER))
+				&& above.is(Fluids.FLOWING_WATER) && above.getValue(BlockStateProperties.FALLING)) {
+			boolean continuesDown = below.is(Fluids.FLOWING_WATER) && below.getValue(BlockStateProperties.FALLING);
+			if (!continuesDown) {
+				return true;
+			}
+		}
+
 		Fluid sourceForAbove = CustomFluidSupport.sourceFor(above);
 		return sourceForAbove != null && state.is(sourceForAbove) && below.is(sourceForAbove);
 	}

--- a/versions/1.21.1/common/src/main/java/com/leclowndu93150/particular/mixin/InjectFlowableFluid.java
+++ b/versions/1.21.1/common/src/main/java/com/leclowndu93150/particular/mixin/InjectFlowableFluid.java
@@ -24,7 +24,7 @@ public class InjectFlowableFluid
 	{
 		if (!ParticularConfig.cascades()) { return; }
 
-		if (random.nextInt(10) == 0 && (state.is(Fluids.WATER) || CustomFluidSupport.isWaterLike(state))) {
+		if (random.nextInt(10) == 0 && (state.is(Fluids.WATER) || state.is(Fluids.FLOWING_WATER) || CustomFluidSupport.isWaterLike(state))) {
 			CommonClass.updateCascade(level, pos, state);
 		}
 	}


### PR DESCRIPTION
## What

Make cascade particles fire when **flowing** water (e.g. bucket-spilled water) drops a block in elevation, not only where a falling column lands in a still source pool.

## Why

`isCascadeLocation` previously required a water **source** at the position, flowing water above, and a water **source** below — i.e. a waterfall landing into a still pool. Spilled flowing water pouring over a ledge onto bare ground (or a shallow flowing puddle) never satisfied that, so it produced no cascade foam.

## Changes (`versions/1.21.1`)

- **`InjectFlowableFluid`**: allow flowing water (not just source) to reach the cascade check, so spilled water is considered at all.
- **`CommonClass.isCascadeLocation`**: add a case that fires at the **base of a falling-water drop** — `FALLING` water directly above and the fall terminating at this block. The terminate check (the block below isn't itself a falling column) means a tall column isn't spammed with foam at every level; it fires once at the bottom of the drop.

Reuses the existing renderer geometry (`pos` = landing surface, `pos.above()` = falling column) and rides on the existing `cascades` config toggle, so there are no new settings.

## Testing

Manually verified in a dev client (Fabric, 1.21.1): pour a water bucket over a 1-block ledge and the cascade foam now appears at the spill point. Toggling `cascades` off removes it as expected.

## Note

This is applied to `versions/1.21.1` only. Happy to port the identical change to `1.20.1`, `26.1.2`, and `26.2` if you'd like it across all bundled versions.